### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "test": "make test",
     "prepublish": "make build",
-    "postinstall": "./bin/install",
-    "postupdate": "./bin/install",
-    "preuninstall": "./bin/uninstall"
+    "postinstall": "node bin/install",
+    "postupdate": "node bin/install",
+    "preuninstall": "node bin/uninstall"
   },
   "bin": {
-    "git-scripts": "./bin/git-scripts"
+    "git-scripts": "node bin/git-scripts"
   },
   "keywords": [
     "git",


### PR DESCRIPTION
Hello,

I have problems in using git-scripts on windows : when I run git-scripts, I have this error :
./bin/install is not recognized as internal or external command

I tried to modify the package.json according to http://shapeshed.com/writing-cross-platform-node/ title "Scripts in package.json".
But it still don't work...

Maybe the problem is doing the symlink of git-hook in directory ?
What do think about that ?

Thanks,
Bertrand
