### PR TITLE
windows symlink type should be 'junction' for folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 lib-cov
 *.seed
 *.log

--- a/lib/git-scripts.js
+++ b/lib/git-scripts.js
@@ -1,5 +1,6 @@
 
 var fs = require('fs')
+  , os = require('os')
   , path = require('path')
   , spawn = require('child_process').spawn;
 
@@ -52,7 +53,7 @@ GitScripts.prototype.install = function(callback) {
             if (err) return callback(err);
 
             var hooksSrcPath = __dirname + '/../bin/hooks';
-            fs.symlink(path.relative(self.gitPath, hooksSrcPath), self.hooksPath, callback);
+            fs.symlink(path.relative(self.gitPath, hooksSrcPath), self.hooksPath, os.platform() == 'win32' ? 'junction' : 'file', callback);
           });
         }
       });


### PR DESCRIPTION
Error during installation on windows machines.
`fs.symlink` with default type 'file' fails with EPERM.